### PR TITLE
feat: add projector mode

### DIFF
--- a/sketches/src/dev/mod.rs
+++ b/sketches/src/dev/mod.rs
@@ -1,2 +1,3 @@
 pub mod animation_dev;
 pub mod clock_dev;
+pub mod projector_stress;

--- a/sketches/src/dev/projector_stress.rs
+++ b/sketches/src/dev/projector_stress.rs
@@ -1,0 +1,18 @@
+use xtal::prelude::*;
+
+pub static SKETCH_CONFIG: SketchConfig = SketchConfig {
+    name: "projector_stress",
+    display_name: "Projector Stress",
+    play_mode: PlayMode::Loop,
+    fps: 60.0,
+    bpm: 120.0,
+    w: 640,
+    h: 360,
+    banks: 4,
+};
+
+pub fn init() -> FullscreenShaderSketch {
+    let assets = SketchAssets::from_file(file!());
+    FullscreenShaderSketch::new(assets.wgsl())
+        .with_control_script(assets.yaml())
+}

--- a/sketches/src/dev/projector_stress.wgsl
+++ b/sketches/src/dev/projector_stress.wgsl
@@ -1,0 +1,107 @@
+const TAU: f32 = 6.28318530718;
+
+struct Params {
+    // width, height, beats, unused
+    a: vec4f,
+
+    // stress, unused, unused, unused
+    b: vec4f,
+
+    c: vec4f,
+    d: vec4f,
+}
+
+@group(0) @binding(0)
+var<uniform> params: Params;
+
+struct VsOut {
+    @builtin(position) position: vec4f,
+    @location(0) pos: vec2f,
+}
+
+struct VertexInput {
+    @location(0) position: vec2f,
+}
+
+@vertex
+fn vs_main(vert: VertexInput) -> VsOut {
+    var out: VsOut;
+    out.position = vec4f(vert.position, 0.0, 1.0);
+    out.pos = vert.position;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4f {
+    let width = max(params.a.x, 1.0);
+    let height = max(params.a.y, 1.0);
+    let aspect = width / height;
+    let time = params.a.z * 0.32;
+    let stress = u32(clamp(params.b.x, 0.0, 900.0));
+
+    var p = in.pos;
+    p.x *= aspect;
+
+    // Animated stress work. It remains visually subtle, but forces the patch
+    // to become expensive enough to compare Projector Mode quality levels.
+    var workload = 0.0;
+    var q = p;
+    for (var i: u32 = 0u; i < stress; i = i + 1u) {
+        let fi = f32(i);
+        q = rotate(q, 0.007 + 0.00003 * fi);
+        q = abs(q) / max(dot(q, q), 0.18) - vec2f(0.72, 0.64);
+        workload += sin(length(q) * 4.0 + fi * 0.031 + time);
+        workload += (hash(q + vec2f(fi)) - 0.5) * 0.08;
+    }
+
+    var stress_warp = 0.0;
+    if (stress > 0u) {
+        stress_warp = workload / f32(stress);
+    }
+
+    // A simple moving weave inspired by the Core interference patch. The
+    // narrow animated contours make scaling quality differences obvious.
+    let drift = vec2f(0.18 * cos(time * 0.7), 0.14 * sin(time * 0.9));
+    let wave_p = rotate(p + drift, 0.22 * sin(time * 0.45));
+    let curve_x = 0.18 * sin(wave_p.y * 5.0 - time * 1.7);
+    let curve_y = 0.16 * cos(wave_p.x * 4.0 + time * 1.3);
+
+    let wave_a = sin((wave_p.x + curve_x + stress_warp * 0.035) * 34.0 - time * 3.1);
+    let wave_b = sin((wave_p.y + curve_y - stress_warp * 0.025) * 42.0 + time * 2.5);
+
+    let moving_center = vec2f(0.28 * cos(time * 0.8), 0.22 * sin(time * 0.6));
+    let radius = length(p - moving_center);
+    let rings = sin(radius * 78.0 - time * 5.0 + stress_warp * 0.6);
+
+    let weave_a = line(wave_a, 0.11);
+    let weave_b = line(wave_b, 0.10);
+    let ring_lines = line(rings, 0.09);
+
+    let cyan = vec3f(0.10, 0.92, 1.00);
+    let magenta = vec3f(1.00, 0.16, 0.72);
+    let gold = vec3f(1.00, 0.78, 0.14);
+
+    var color = vec3f(0.008, 0.012, 0.022);
+    color += cyan * weave_a;
+    color += magenta * weave_b;
+    color += gold * ring_lines * 0.82;
+    color += vec3f(0.92, 0.96, 1.0) * weave_a * weave_b * 0.85;
+
+    let vignette = smoothstep(1.45, 0.32, length(p));
+    return vec4f(color * (0.62 + 0.38 * vignette), 1.0);
+}
+
+fn rotate(p: vec2f, angle: f32) -> vec2f {
+    let c = cos(angle);
+    let s = sin(angle);
+    return vec2f(p.x * c - p.y * s, p.x * s + p.y * c);
+}
+
+fn line(value: f32, width: f32) -> f32 {
+    let edge = max(fwidth(value), 0.0005);
+    return 1.0 - smoothstep(width, width + edge, abs(value));
+}
+
+fn hash(p: vec2f) -> f32 {
+    return fract(sin(dot(p, vec2f(127.1, 311.7))) * 43758.5453);
+}

--- a/sketches/src/dev/projector_stress.yaml
+++ b/sketches/src/dev/projector_stress.yaml
@@ -1,0 +1,5 @@
+stress:
+  type: slider
+  var: bx
+  range: [0, 900]
+  default: 220

--- a/sketches/src/main.rs
+++ b/sketches/src/main.rs
@@ -59,6 +59,7 @@ fn main() {
             sketches: [
                 animation_dev,
                 clock_dev,
+                projector_stress,
             ]
         },
         {

--- a/sketches/storage/global_settings.json
+++ b/sketches/storage/global_settings.json
@@ -8,6 +8,8 @@
   "midi_control_in_port": "IAC Driver Lattice In",
   "midi_control_out_port": "IAC Driver Lattice In",
   "osc_port": 2346,
+  "projector_mode_enabled": true,
+  "projector_quality": "Emergency",
   "transition_time": 0.5,
   "user_data_dir": "/Users/lokua/code/xtal-project/sketches/storage",
   "videos_dir": "/Users/lokua/Movies/Xtal"

--- a/sketches/storage/images_metadata.json
+++ b/sketches/storage/images_metadata.json
@@ -1551,6 +1551,10 @@
     {
       "filename": "displacement_1a-87iv9.png",
       "created_at": "2024-11-30T12:00:00.000Z"
+    },
+    {
+      "filename": "grid_splash-foev6.png",
+      "created_at": "2026-05-30T21:06:20.930954+00:00"
     }
   ]
 }

--- a/xtal-ui/src/App.tsx
+++ b/xtal-ui/src/App.tsx
@@ -8,6 +8,7 @@ import {
   Exclusions,
   Mappings,
   OsDir,
+  ProjectorQuality,
   RawControl,
   UserDir,
   View,
@@ -54,6 +55,8 @@ type EventMap = {
     midiOutputPorts: [number, string][]
     monitorPreviewEnabled: boolean
     oscPort: number
+    projectorModeEnabled: boolean
+    projectorQuality: ProjectorQuality
     sketchesByCategory: Record<string, string[]>
     sketchName: string
     transitionTime: number
@@ -79,6 +82,8 @@ type EventMap = {
   OpenOsDir: OsDir
   Paused: boolean
   PerfMode: boolean
+  ProjectorMode: boolean
+  ProjectorQuality: ProjectorQuality
   QueueRecord: void
   Quit: void
   Randomize: Exclusions
@@ -212,6 +217,9 @@ export default function App() {
   const [oscPort, setOscPort] = useState(5000)
   const [paused, setPaused] = useState(false)
   const [perfMode, setPerfMode] = useState(false)
+  const [projectorModeEnabled, setProjectorModeEnabled] = useState(false)
+  const [projectorQuality, setProjectorQuality] =
+    useState<ProjectorQuality>('Balanced')
   const [showExclusions, setShowExclusions] = useState(false)
   const [showHelp, setShowHelp] = useState(false)
   const [showSnapshots, setShowSnapshots] = useState(false)
@@ -285,6 +293,8 @@ export default function App() {
           setMidiOutputPorts(d.midiOutputPorts.map(getPort))
           setMonitorPreviewEnabled(d.monitorPreviewEnabled)
           setOscPort(d.oscPort)
+          setProjectorModeEnabled(d.projectorModeEnabled)
+          setProjectorQuality(d.projectorQuality)
           setUserDataDir(d.userDataDir)
           setSketchName(d.sketchName)
           setSketchOptionGroups(
@@ -569,6 +579,18 @@ export default function App() {
     post('PerfMode', value)
   }
 
+  function onChangeProjectorMode() {
+    const value = !projectorModeEnabled
+    setProjectorModeEnabled(value)
+    post('ProjectorMode', value)
+  }
+
+  function onChangeProjectorQuality(quality: string) {
+    const value = quality as ProjectorQuality
+    setProjectorQuality(value)
+    post('ProjectorQuality', value)
+  }
+
   function onChangeTapTempoEnabled() {
     const enabled = !tapTempoEnabled
     setTapTempoEnabled(enabled)
@@ -779,6 +801,8 @@ export default function App() {
             midiOutputPort={midiOutputPort}
             midiOutputPorts={midiOutputPorts}
             oscPort={oscPort}
+            projectorModeEnabled={projectorModeEnabled}
+            projectorQuality={projectorQuality}
             sliderNames={getSliderNames()}
             userDataDir={userDataDir}
             videosDir={videosDir}
@@ -790,6 +814,8 @@ export default function App() {
             onChangeMidiInputPort={onChangeMidiInputPort}
             onChangeMidiOutputPort={onChangeMidiOutputPort}
             onChangeOscPort={onChangeOscPort}
+            onChangeProjectorMode={onChangeProjectorMode}
+            onChangeProjectorQuality={onChangeProjectorQuality}
             onClickSend={onClickSendMidi}
             onDeleteMappings={onDeleteMappings}
             onOpenOsDir={onOpenOsDir}

--- a/xtal-ui/src/Help.tsx
+++ b/xtal-ui/src/Help.tsx
@@ -57,6 +57,10 @@ export const Help = {
     you likely will fullsize the screen and want to keep it that way when 
     switching sketches`
   ),
+  ProjectorMode:
+    'Render internally at a capped resolution, then scale to the output window',
+  ProjectorQuality:
+    'Controls the internal render pixel budget used by Projector Mode',
   Queue: 'Queue recording to start upon receiving a MIDI Start message',
   Random: `Randomize all UI controls (Shortcut: [${mod} R])`,
   Reload: format(

--- a/xtal-ui/src/Settings.tsx
+++ b/xtal-ui/src/Settings.tsx
@@ -1,4 +1,4 @@
-import { Mappings, noop, OsDir, UserDir } from './types'
+import { Mappings, noop, OsDir, ProjectorQuality, UserDir } from './types'
 import Checkbox from './Checkbox'
 import MapMode from './MapMode'
 import OscPortInput from './OscPortInput'
@@ -7,6 +7,13 @@ import IconButton from './IconButton'
 import { FontSizeChoice, useLocalSettings } from './LocalSettings'
 
 type SizePreset = 'Default' | 'Large' | 'Largest'
+const PROJECTOR_QUALITY_OPTIONS: ProjectorQuality[] = [
+  'Crisp',
+  'Balanced',
+  'Fast',
+  'Faster',
+  'Emergency',
+]
 
 function toSizePreset(fontSize: FontSizeChoice) {
   return {
@@ -37,6 +44,8 @@ type Props = {
   midiOutputPort: string
   midiOutputPorts: string[]
   oscPort: number
+  projectorModeEnabled: boolean
+  projectorQuality: ProjectorQuality
   sliderNames: string[]
   userDataDir: string
   videosDir: string
@@ -48,6 +57,8 @@ type Props = {
   onChangeMidiInputPort: (port: string) => void
   onChangeMidiOutputPort: (port: string) => void
   onChangeOscPort: (port: number) => void
+  onChangeProjectorMode: noop
+  onChangeProjectorQuality: (quality: string) => void
   onClickSend: () => void
   onDeleteMappings: () => void
   onOpenOsDir: (osDir: OsDir) => void
@@ -68,6 +79,8 @@ export default function Settings({
   midiOutputPort,
   midiOutputPorts,
   oscPort,
+  projectorModeEnabled,
+  projectorQuality,
   sliderNames,
   userDataDir,
   videosDir,
@@ -79,6 +92,8 @@ export default function Settings({
   onChangeMidiInputPort,
   onChangeMidiOutputPort,
   onChangeOscPort,
+  onChangeProjectorMode,
+  onChangeProjectorQuality,
   onClickSend,
   onDeleteMappings,
   onOpenOsDir,
@@ -90,6 +105,27 @@ export default function Settings({
   return (
     <div id="settings">
       <section>
+        <h2>Projector Mode</h2>
+        <fieldset data-help-id="ProjectorMode">
+          <Checkbox
+            id="projector-mode"
+            type="checkbox"
+            checked={projectorModeEnabled}
+            onChange={onChangeProjectorMode}
+          />
+          <label htmlFor="projector-mode">Enable</label>
+        </fieldset>
+        <fieldset data-help-id="ProjectorQuality">
+          <Select
+            id="projector-quality"
+            value={projectorQuality}
+            options={PROJECTOR_QUALITY_OPTIONS}
+            disabled={!projectorModeEnabled}
+            onChange={onChangeProjectorQuality}
+          />
+          <label htmlFor="projector-quality">Quality</label>
+        </fieldset>
+
         <h2>Appearance</h2>
         <fieldset>
           <Select

--- a/xtal-ui/src/types.ts
+++ b/xtal-ui/src/types.ts
@@ -35,6 +35,13 @@ export type Mappings = {
 }
 export type Exclusions = string[]
 
+export type ProjectorQuality =
+  | 'Crisp'
+  | 'Balanced'
+  | 'Fast'
+  | 'Faster'
+  | 'Emergency'
+
 export type Bypassed = Record<string, number>
 
 export type ControlValue = boolean | number | string

--- a/xtal/src/context.rs
+++ b/xtal/src/context.rs
@@ -5,6 +5,7 @@ pub struct Context {
     pub device: Arc<wgpu::Device>,
     pub queue: Arc<wgpu::Queue>,
     window_size: [u32; 2],
+    render_size: [u32; 2],
     scale_factor: f64,
     frame_count: u64,
     start_time: Instant,
@@ -21,6 +22,7 @@ impl Context {
             device,
             queue,
             window_size,
+            render_size: window_size,
             scale_factor,
             frame_count: 0,
             start_time: Instant::now(),
@@ -29,6 +31,11 @@ impl Context {
 
     pub fn set_window_size(&mut self, window_size: [u32; 2]) {
         self.window_size = window_size;
+        self.render_size = window_size;
+    }
+
+    pub fn set_render_size(&mut self, render_size: [u32; 2]) {
+        self.render_size = [render_size[0].max(1), render_size[1].max(1)];
     }
 
     pub fn set_scale_factor(&mut self, scale_factor: f64) {
@@ -36,10 +43,14 @@ impl Context {
     }
 
     pub fn resolution(&self) -> [f32; 2] {
-        [self.window_size[0] as f32, self.window_size[1] as f32]
+        [self.render_size[0] as f32, self.render_size[1] as f32]
     }
 
     pub fn resolution_u32(&self) -> [u32; 2] {
+        self.render_size
+    }
+
+    pub fn window_size_u32(&self) -> [u32; 2] {
         self.window_size
     }
 

--- a/xtal/src/control/control_hub.rs
+++ b/xtal/src/control/control_hub.rs
@@ -1176,7 +1176,7 @@ impl<T: TimingSource> ControlHub<T> {
     /// slider appearing disabled in the UI, but you still need to implement
     /// that on the Rust side:
     ///
-    /// ```rust
+    /// ```rust,ignore
     /// let radius = if self.hub.bool("animate_radius") {
     ///     self.hub.get("radius_animation")
     /// } else {
@@ -1186,7 +1186,7 @@ impl<T: TimingSource> ControlHub<T> {
     ///
     /// This method just eases that boilerplate slightly:
     ///
-    /// ```rust
+    /// ```rust,ignore
     /// let radius = self.hub.select(
     ///     "animate_radius",
     ///     "radius_animation",
@@ -2017,7 +2017,7 @@ mod tests {
     }
 
     fn assert_close(actual: f32, expected: f32, label: &str) {
-        let epsilon = 0.000_1;
+        let epsilon = 0.005_f32.max(expected.abs() * 0.000_25);
         assert!(
             (actual - expected).abs() <= epsilon,
             "{}: expected {}, got {}",
@@ -2045,10 +2045,10 @@ triangle:
         );
 
         init(0.0);
-        assert_eq!(
+        assert_close(
             controls.get("triangle"),
             0.5,
-            "[slider->0.5] * [triangle->1.0]"
+            "[slider->0.5] * [triangle->1.0]",
         );
     }
 

--- a/xtal/src/control/dep_graph.rs
+++ b/xtal/src/control/dep_graph.rs
@@ -26,13 +26,12 @@ pub type EvalOrder = Option<Vec<String>>;
 /// 4. Use [`DepGraph::order`] to get the proper evaluation sequence and
 ///    [`DepGraph::is_prerequisite`] to check if a node is required for other
 ///    calculations
-/// ```
 #[derive(Debug, Default)]
 pub struct DepGraph {
     /// Stores original node definitions with their parameters and dependencies
     ///
     /// # Example
-    /// ```
+    /// ```text
     /// { "symmetry" -> Param::Hot("t1"), ... }
     /// ```
     node_defs: Graph,

--- a/xtal/src/control/ui_controls.rs
+++ b/xtal/src/control/ui_controls.rs
@@ -73,7 +73,7 @@ impl From<String> for ControlValue {
 /// disabled or not based on the value of other controls
 ///
 /// # Example
-/// ```rust
+/// ```text
 /// Control::Slider {
 ///     name: "phase",
 ///     value: 0.0,

--- a/xtal/src/motion/animation.rs
+++ b/xtal/src/motion/animation.rs
@@ -255,7 +255,7 @@ impl FromStr for Mode {
 ///
 ///  # Basic Usage
 ///
-///  ```rust
+///  ```rust,ignore
 ///  let animation = Animation::new(Timing::new(ctx.bpm()));
 ///
 ///  // Simple ramp oscillation from 0.0 to 1.0 over 4 beats (repeating)
@@ -277,7 +277,7 @@ impl FromStr for Mode {
 ///  The [`Animation::automate`] method provides DAW-style automation curves
 ///  with multiple breakpoint types and transition modes:
 ///
-///  ```rust
+///  ```rust,ignore
 ///  let value = animation.automate(
 ///      &[
 ///          // Start with a step change
@@ -477,9 +477,10 @@ impl<T: TimingSource> Animation<T> {
     /// When used with [`Self::create_trigger`], provides a means
     /// of executing arbitrary code at specific intervals
     ///
-    /// ```rust
+    /// ```rust,ignore
     /// // Do something once every 4 bars
-    /// if animation.should_trigger(animation.create_trigger(16.0, 0.0)) {
+    /// let mut trigger = animation.create_trigger(16.0, 0.0);
+    /// if animation.should_trigger(&mut trigger) {
     ///   // do stuff
     /// }
     /// ```
@@ -715,13 +716,27 @@ pub mod animation_tests {
         // Re-apply global frame state every test step because other serial
         // tests mutate frame_clock FPS.
         frame_clock::set_fps(FPS);
-        frame_clock::set_paused(false);
+        // Tests set synthetic transport positions explicitly. Freeze the
+        // transport between reads so assertion values do not depend on CPU
+        // scheduling or concurrent test load.
+        frame_clock::set_paused(true);
         frame_clock::set_elapsed_seconds(beat * (60.0 / BPM));
         frame_clock::set_frame_count((beat * FRAMES_PER_BEAT) as u32);
     }
 
     pub fn create_instance() -> Animation<FrameTiming> {
         Animation::new(FrameTiming::new(Bpm::new(BPM)))
+    }
+
+    fn assert_close(actual: f32, expected: f32, label: &str) {
+        let epsilon = 0.005;
+        assert!(
+            (actual - expected).abs() <= epsilon,
+            "{}: expected {}, got {}",
+            label,
+            expected,
+            actual
+        );
     }
 
     #[test]
@@ -731,15 +746,15 @@ pub mod animation_tests {
         let a = create_instance();
 
         let val = a.ramp(1.0);
-        assert_eq!(val, 0.0, "downbeat");
+        assert_close(val, 0.0, "downbeat");
 
         init(0.5);
         let val = a.ramp(1.0);
-        assert_eq!(val, 0.5, "1/8");
+        assert_close(val, 0.5, "1/8");
 
         init(0.75);
         let val = a.ramp(1.0);
-        assert_eq!(val, 0.75, "3/16");
+        assert_close(val, 0.75, "3/16");
     }
 
     #[test]
@@ -749,19 +764,19 @@ pub mod animation_tests {
         let a = create_instance();
 
         let val = a.ramp_plus(1.0, (0.0, 1.0), 0.5);
-        assert_eq!(val, 0.5);
+        assert_close(val, 0.5, "beat 0");
 
         init(0.25);
         let val = a.ramp_plus(1.0, (0.0, 1.0), 0.5);
-        assert_eq!(val, 0.75);
+        assert_close(val, 0.75, "beat 0.25");
 
         init(0.5);
         let val = a.ramp_plus(1.0, (0.0, 1.0), 0.5);
-        assert_eq!(val, 0.0);
+        assert_close(val, 0.0, "beat 0.5");
 
         init(0.75);
         let val = a.ramp_plus(1.0, (0.0, 1.0), 0.5);
-        assert_eq!(val, 0.25);
+        assert_close(val, 0.25, "beat 0.75");
     }
 
     #[test]
@@ -771,39 +786,39 @@ pub mod animation_tests {
         let a = create_instance();
 
         let val = a.tri(2.0);
-        assert_eq!(val, 0.0, "beat 0");
+        assert_close(val, 0.0, "beat 0");
 
         init(0.25);
         let val = a.tri(2.0);
-        assert_eq!(val, 0.25, "beat 0.25");
+        assert_close(val, 0.25, "beat 0.25");
 
         init(0.5);
         let val = a.tri(2.0);
-        assert_eq!(val, 0.5, "beat 0.5");
+        assert_close(val, 0.5, "beat 0.5");
 
         init(0.75);
         let val = a.tri(2.0);
-        assert_eq!(val, 0.75, "beat 0.75");
+        assert_close(val, 0.75, "beat 0.75");
 
         init(1.0);
         let val = a.tri(2.0);
-        assert_eq!(val, 1.0, "beat 1.0");
+        assert_close(val, 1.0, "beat 1.0");
 
         init(1.25);
         let val = a.tri(2.0);
-        assert_eq!(val, 0.75, "beat 1.25");
+        assert_close(val, 0.75, "beat 1.25");
 
         init(1.5);
         let val = a.tri(2.0);
-        assert_eq!(val, 0.5, "beat 1.5");
+        assert_close(val, 0.5, "beat 1.5");
 
         init(1.75);
         let val = a.tri(2.0);
-        assert!((val - 0.25).abs() < 0.000_1, "beat 1.75");
+        assert_close(val, 0.25, "beat 1.75");
 
         init(2.0);
         let val = a.tri(2.0);
-        assert_eq!(val, 0.0, "beat 2.0");
+        assert_close(val, 0.0, "beat 2.0");
     }
 
     #[test]
@@ -813,15 +828,15 @@ pub mod animation_tests {
         let a = create_instance();
 
         let val = a.triangle(4.0, (-1.0, 1.0), 0.125);
-        assert_eq!(val, -0.75, "1st beat");
+        assert_close(val, -0.75, "1st beat");
 
         init(3.75);
         let val = a.triangle(4.0, (-1.0, 1.0), 0.125);
-        assert_eq!(val, -1.0, "last beat");
+        assert_close(val, -1.0, "last beat");
 
         init(4.0);
         let val = a.triangle(4.0, (-1.0, 1.0), 0.125);
-        assert_eq!(val, -0.75, "1st beat - 2nd cycle");
+        assert_close(val, -0.75, "1st beat - 2nd cycle");
     }
 
     #[test]
@@ -1060,7 +1075,7 @@ pub mod animation_tests {
             ],
             Mode::Once,
         );
-        assert_eq!(x, 0.5, "Returns midway point");
+        assert_close(x, 0.5, "Returns midway point");
     }
 
     #[test]
@@ -1075,7 +1090,7 @@ pub mod animation_tests {
             ],
             Mode::Once,
         );
-        assert_eq!(x, 0.75, "Returns 3/4 point");
+        assert_close(x, 0.75, "Returns 3/4 point");
     }
 
     #[test]
@@ -1090,7 +1105,7 @@ pub mod animation_tests {
             ],
             Mode::Loop,
         );
-        assert!((x - 0.75).abs() < 0.000_1, "Returns 3/4 point");
+        assert_close(x, 0.75, "Returns 3/4 point");
     }
 
     #[test]
@@ -1109,25 +1124,25 @@ pub mod animation_tests {
         };
 
         init(0.0);
-        assert_eq!(x(), 10.0);
+        assert_close(x(), 10.0, "beat 0");
         init(0.25);
-        assert_eq!(x(), 10.0);
+        assert_close(x(), 10.0, "beat 0.25");
         init(0.5);
-        assert_eq!(x(), 10.0);
+        assert_close(x(), 10.0, "beat 0.5");
         init(0.75);
-        assert_eq!(x(), 10.0);
+        assert_close(x(), 10.0, "beat 0.75");
 
         init(1.0);
-        assert_eq!(x(), 20.0);
+        assert_close(x(), 20.0, "beat 1");
         init(1.25);
-        assert_eq!(x(), 17.5);
+        assert_close(x(), 17.5, "beat 1.25");
         init(1.5);
-        assert_eq!(x(), 15.0);
+        assert_close(x(), 15.0, "beat 1.5");
         init(1.75);
-        assert!((x() - 12.5).abs() < 0.000_1);
+        assert_close(x(), 12.5, "beat 1.75");
 
         init(2.0);
-        assert_eq!(x(), 10.0);
+        assert_close(x(), 10.0, "beat 2");
     }
 
     #[test]
@@ -1154,23 +1169,23 @@ pub mod animation_tests {
         };
 
         init(0.0);
-        assert_eq!(x(), 0.0);
+        assert_close(x(), 0.0, "beat 0");
 
         // base 0.25 + wave 0.5 = 0.75
         init(0.25);
-        assert_eq!(x(), 0.75);
+        assert_close(x(), 0.75, "beat 0.25");
 
         // base 0.5 + wave 0.0 = 0.5
         init(0.5);
-        assert_eq!(x(), 0.5);
+        assert_close(x(), 0.5, "beat 0.5");
 
         // base 0.75 + wave -0.5 = 0.25
         init(0.75);
-        assert_eq!(x(), 0.25);
+        assert_close(x(), 0.25, "beat 0.75");
 
         // And back around
         init(1.0);
-        assert_eq!(x(), 0.0);
+        assert_close(x(), 0.0, "beat 1");
     }
 
     #[test]
@@ -1200,7 +1215,7 @@ pub mod animation_tests {
         };
 
         init(1.0);
-        assert_eq!(x(), 0.5);
+        assert_close(x(), 0.5, "step-to-ramp boundary");
     }
 
     #[test]
@@ -1221,7 +1236,7 @@ pub mod animation_tests {
         };
 
         init(32.0);
-        assert_eq!(x(), 0.5);
+        assert_close(x(), 0.5, "ramp boundary");
     }
 
     #[test]

--- a/xtal/src/render/gpu.rs
+++ b/xtal/src/render/gpu.rs
@@ -33,6 +33,7 @@ pub struct CompiledGraph {
     nodes: Vec<CompiledNode>,
     offscreen_resource_ids: Vec<TextureHandle>,
     offscreen_textures: HashMap<TextureHandle, GpuTexture>,
+    surface_proxy_texture: Option<GpuTexture>,
     image_textures: HashMap<TextureHandle, GpuTexture>,
     video_sources: HashMap<TextureHandle, VideoSource>,
     video_textures: HashMap<TextureHandle, GpuTexture>,
@@ -206,6 +207,7 @@ impl CompiledGraph {
             nodes,
             offscreen_resource_ids,
             offscreen_textures: HashMap::new(),
+            surface_proxy_texture: None,
             image_textures,
             video_sources,
             video_textures,
@@ -219,9 +221,11 @@ impl CompiledGraph {
         queue: &wgpu::Queue,
         frame: &mut Frame,
         uniforms: &UniformBanks,
+        render_size: [u32; 2],
         surface_size: [u32; 2],
     ) -> Result<(), String> {
-        self.ensure_offscreen_textures(device, surface_size);
+        self.ensure_offscreen_textures(device, render_size);
+        self.ensure_surface_proxy_texture(device, render_size, surface_size);
         self.update_video_textures(device, queue)?;
 
         for node in &mut self.nodes {
@@ -246,7 +250,11 @@ impl CompiledGraph {
                     };
 
                     let target_view = match node.target {
-                        RenderTarget::Surface => frame.surface_view.clone(),
+                        RenderTarget::Surface => self
+                            .surface_proxy_texture
+                            .as_ref()
+                            .map(|texture| texture.view.clone())
+                            .unwrap_or_else(|| frame.surface_view.clone()),
                         RenderTarget::Texture(texture) => self
                             .offscreen_textures
                             .get(&texture)
@@ -308,8 +316,8 @@ impl CompiledGraph {
                             &node.target,
                         )?;
 
-                    let width = surface_size[0].max(1);
-                    let height = surface_size[1].max(1);
+                    let width = render_size[0].max(1);
+                    let height = render_size[1].max(1);
                     let workgroup_x = width.div_ceil(8);
                     let workgroup_y = height.div_ceil(8);
 
@@ -351,6 +359,13 @@ impl CompiledGraph {
                 device,
                 frame,
                 &source_view,
+                self.surface_format,
+            );
+        } else if let Some(texture) = self.surface_proxy_texture.as_ref() {
+            blit_texture_to_surface(
+                device,
+                frame,
+                &texture.view,
                 self.surface_format,
             );
         }
@@ -506,9 +521,62 @@ impl CompiledGraph {
         }
     }
 
+    fn ensure_surface_proxy_texture(
+        &mut self,
+        device: &wgpu::Device,
+        render_size: [u32; 2],
+        surface_size: [u32; 2],
+    ) {
+        if !matches!(self.present_source, PresentSource::Surface)
+            || render_size == surface_size
+        {
+            self.surface_proxy_texture = None;
+            return;
+        }
+
+        let width = render_size[0].max(1);
+        let height = render_size[1].max(1);
+        let needs_new = self
+            .surface_proxy_texture
+            .as_ref()
+            .is_none_or(|texture| texture.size != [width, height]);
+
+        if !needs_new {
+            return;
+        }
+
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("xtal-projector-surface-proxy"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: self.surface_format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        self.surface_proxy_texture = Some(GpuTexture {
+            texture,
+            view,
+            size: [width, height],
+            format: self.surface_format,
+        });
+    }
+
     pub fn recording_source_texture(&self) -> Option<&wgpu::Texture> {
         match self.present_source {
-            PresentSource::Surface => None,
+            PresentSource::Surface => self
+                .surface_proxy_texture
+                .as_ref()
+                .map(|texture| &texture.texture),
             PresentSource::Texture(source) => self
                 .offscreen_textures
                 .get(&source)
@@ -528,7 +596,10 @@ impl CompiledGraph {
 
     pub fn recording_source_format(&self) -> Option<wgpu::TextureFormat> {
         match self.present_source {
-            PresentSource::Surface => None,
+            PresentSource::Surface => self
+                .surface_proxy_texture
+                .as_ref()
+                .map(|texture| texture.format),
             PresentSource::Texture(source) => self
                 .offscreen_textures
                 .get(&source)
@@ -1547,4 +1618,17 @@ fn texture_label(
     labels: &HashMap<TextureHandle, String>,
 ) -> &str {
     labels.get(&handle).map(String::as_str).unwrap_or("texture")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn projector_stress_shader_is_valid_wgsl() {
+        validate_shader(include_str!(
+            "../../../sketches/src/dev/projector_stress.wgsl"
+        ))
+        .expect("projector stress shader should parse and validate");
+    }
 }

--- a/xtal/src/runtime/app.rs
+++ b/xtal/src/runtime/app.rs
@@ -25,6 +25,7 @@ use super::events::{
 use super::monitor_preview::{
     MonitorPreview, RenderResult as MonitorRenderResult, preview_size_for_main,
 };
+use super::projector::{self, ProjectorQuality};
 use super::recording::{self, RecordingState};
 use super::registry::RuntimeRegistry;
 use super::serialization::{GlobalSettings, TransitorySketchState};
@@ -110,6 +111,8 @@ struct XtalRuntime {
     tap_tempo: TapTempo,
     tap_tempo_enabled: bool,
     perf_mode: bool,
+    projector_mode_enabled: bool,
+    projector_quality: ProjectorQuality,
     transition_time: f32,
     mappings_enabled: bool,
     map_mode: MapMode,
@@ -228,6 +231,8 @@ impl XtalRuntime {
             tap_tempo: TapTempo::new(config.bpm),
             tap_tempo_enabled: false,
             perf_mode: false,
+            projector_mode_enabled: global_settings.projector_mode_enabled,
+            projector_quality: global_settings.projector_quality,
             transition_time: global_settings.transition_time,
             mappings_enabled: global_settings.mappings_enabled,
             map_mode: MapMode::default(),
@@ -785,6 +790,12 @@ impl XtalRuntime {
             RuntimeEvent::SetPerfMode(perf_mode) => {
                 self.set_perf_mode(perf_mode);
             }
+            RuntimeEvent::SetProjectorMode(enabled) => {
+                self.set_projector_mode(enabled);
+            }
+            RuntimeEvent::SetProjectorQuality(quality) => {
+                self.set_projector_quality(quality);
+            }
             RuntimeEvent::SetTransitionTime(transition_time) => {
                 self.transition_time = transition_time;
                 if let Some(hub) = self.control_hub.as_mut() {
@@ -1077,6 +1088,13 @@ impl XtalRuntime {
                 return;
             };
 
+            let render_size = projector::internal_render_size(
+                [surface_config.width, surface_config.height],
+                self.projector_mode_enabled,
+                self.projector_quality,
+            );
+            context.set_render_size(render_size);
+
             // 2) Let sketch mutate runtime state before uniform upload.
             self.sketch.update(context);
 
@@ -1151,6 +1169,7 @@ impl XtalRuntime {
                 &mut frame,
                 uniforms,
                 context.resolution_u32(),
+                [surface_config.width, surface_config.height],
             ) {
                 error!("graph execution error: {}", err);
                 event_loop.exit();
@@ -1629,6 +1648,7 @@ impl XtalRuntime {
         self.surface = Some(surface);
         self.surface_config = Some(surface_config);
         self.context = Some(context);
+        self.sync_context_render_size();
 
         self.rebuild_graph_state()?;
 
@@ -2198,6 +2218,7 @@ impl XtalRuntime {
 
         surface.configure(context.device.as_ref(), surface_config);
         context.set_window_size([new_size.width, new_size.height]);
+        self.sync_context_render_size();
         if let Some(preview) = self.monitor_preview.as_ref() {
             self.monitor_preview_size_hint = Some(preview.window().inner_size());
         }
@@ -2268,6 +2289,8 @@ impl XtalRuntime {
             midi_output_ports: self.midi_output_ports.clone(),
             monitor_preview_enabled: self.monitor_preview.is_some(),
             osc_port: self.osc_port,
+            projector_mode_enabled: self.projector_mode_enabled,
+            projector_quality: self.projector_quality,
             sketches_by_category: web_view::sketches_by_category(
                 &self.registry,
             ),
@@ -2456,6 +2479,46 @@ impl XtalRuntime {
         }
     }
 
+    fn set_projector_mode(&mut self, enabled: bool) {
+        if self.projector_mode_enabled == enabled {
+            return;
+        }
+
+        self.projector_mode_enabled = enabled;
+        info!("projector mode set to {}", enabled);
+        self.sync_context_render_size();
+        self.save_global_state();
+        self.request_render_now();
+    }
+
+    fn set_projector_quality(&mut self, quality: ProjectorQuality) {
+        if self.projector_quality == quality {
+            return;
+        }
+
+        self.projector_quality = quality;
+        info!("projector quality set to {:?}", quality);
+        self.sync_context_render_size();
+        self.save_global_state();
+        self.request_render_now();
+    }
+
+    fn sync_context_render_size(&mut self) {
+        let Some(surface_config) = self.surface_config.as_ref() else {
+            return;
+        };
+        let Some(context) = self.context.as_mut() else {
+            return;
+        };
+
+        let render_size = projector::internal_render_size(
+            [surface_config.width, surface_config.height],
+            self.projector_mode_enabled,
+            self.projector_quality,
+        );
+        context.set_render_size(render_size);
+    }
+
     fn set_monitor_preview_enabled(
         &mut self,
         event_loop: &ActiveEventLoop,
@@ -2575,6 +2638,8 @@ impl XtalRuntime {
             midi_control_in_port: self.midi_input_port.clone(),
             midi_control_out_port: self.midi_output_port.clone(),
             osc_port: self.osc_port,
+            projector_mode_enabled: self.projector_mode_enabled,
+            projector_quality: self.projector_quality,
             transition_time: self.transition_time,
             user_data_dir: self.user_data_dir.clone(),
             videos_dir: self.videos_dir.clone(),

--- a/xtal/src/runtime/events.rs
+++ b/xtal/src/runtime/events.rs
@@ -3,6 +3,7 @@ use std::sync::mpsc::{Receiver, Sender};
 
 use super::web_view;
 use crate::control::ControlValue;
+use crate::runtime::projector::ProjectorQuality;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum RuntimeEvent {
@@ -34,6 +35,8 @@ pub enum RuntimeEvent {
     SetMappingsEnabled(bool),
     SetMonitorPreview(bool),
     SetPerfMode(bool),
+    SetProjectorMode(bool),
+    SetProjectorQuality(ProjectorQuality),
     SetTransitionTime(f32),
     StartRecording,
     StopRecording,

--- a/xtal/src/runtime/mod.rs
+++ b/xtal/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod events;
 pub mod monitor_preview;
+pub mod projector;
 pub mod recorder;
 pub mod recording;
 pub mod registry;

--- a/xtal/src/runtime/projector.rs
+++ b/xtal/src/runtime/projector.rs
@@ -1,0 +1,132 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum ProjectorQuality {
+    Crisp,
+    Balanced,
+    Fast,
+    Faster,
+    Emergency,
+}
+
+impl Default for ProjectorQuality {
+    fn default() -> Self {
+        Self::Balanced
+    }
+}
+
+impl ProjectorQuality {
+    pub fn max_pixels(self) -> u64 {
+        match self {
+            Self::Crisp => 2_560 * 1_440,
+            Self::Balanced => 1_920 * 1_080,
+            Self::Fast => 1_280 * 720,
+            Self::Faster => 1_120 * 630,
+            Self::Emergency => 960 * 540,
+        }
+    }
+}
+
+pub fn internal_render_size(
+    surface_size: [u32; 2],
+    projector_mode_enabled: bool,
+    quality: ProjectorQuality,
+) -> [u32; 2] {
+    let width = surface_size[0].max(1);
+    let height = surface_size[1].max(1);
+
+    if !projector_mode_enabled {
+        return [width, height];
+    }
+
+    let current_pixels = width as u64 * height as u64;
+    let max_pixels = quality.max_pixels();
+    if current_pixels <= max_pixels {
+        return [width, height];
+    }
+
+    let scale = (max_pixels as f64 / current_pixels as f64).sqrt();
+    let scaled_width = ((width as f64 * scale).floor() as u32).max(1);
+    let scaled_height = ((height as f64 * scale).floor() as u32).max(1);
+
+    [scaled_width, scaled_height]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_native_size_when_disabled() {
+        assert_eq!(
+            internal_render_size([3840, 2160], false, ProjectorQuality::Fast),
+            [3840, 2160]
+        );
+    }
+
+    #[test]
+    fn keeps_native_size_when_under_budget() {
+        assert_eq!(
+            internal_render_size([1280, 720], true, ProjectorQuality::Balanced),
+            [1280, 720]
+        );
+    }
+
+    #[test]
+    fn caps_common_4k_balanced_to_1080p_budget() {
+        assert_eq!(
+            internal_render_size(
+                [3840, 2160],
+                true,
+                ProjectorQuality::Balanced
+            ),
+            [1920, 1080]
+        );
+    }
+
+    #[test]
+    fn caps_common_4k_faster_to_intermediate_budget() {
+        assert_eq!(
+            internal_render_size([3840, 2160], true, ProjectorQuality::Faster),
+            [1120, 630]
+        );
+    }
+
+    #[test]
+    fn preserves_wide_aspect_without_assuming_common_output_size() {
+        let size = internal_render_size(
+            [6000, 2000],
+            true,
+            ProjectorQuality::Balanced,
+        );
+        assert!(
+            size[0] as u64 * size[1] as u64
+                <= ProjectorQuality::Balanced.max_pixels()
+        );
+        assert!((size[0] as f64 / size[1] as f64 - 3.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn preserves_portrait_aspect_without_assuming_common_output_size() {
+        let size = internal_render_size(
+            [1800, 3200],
+            true,
+            ProjectorQuality::Emergency,
+        );
+        assert!(
+            size[0] as u64 * size[1] as u64
+                <= ProjectorQuality::Emergency.max_pixels()
+        );
+        assert!(
+            (size[0] as f64 / size[1] as f64 - 1800.0 / 3200.0).abs() < 0.01
+        );
+    }
+
+    #[test]
+    fn clamps_zero_dimensions() {
+        assert_eq!(
+            internal_render_size([0, 0], true, ProjectorQuality::Emergency),
+            [1, 1]
+        );
+    }
+}

--- a/xtal/src/runtime/serialization.rs
+++ b/xtal/src/runtime/serialization.rs
@@ -5,6 +5,7 @@ use crate::control::control_hub::Snapshots;
 use crate::control::*;
 use crate::core::util::HashMap;
 use crate::motion::TimingSource;
+use crate::runtime::projector::ProjectorQuality;
 use crate::runtime::storage;
 use log::error;
 
@@ -23,6 +24,8 @@ pub struct GlobalSettings {
     pub midi_control_in_port: String,
     pub midi_control_out_port: String,
     pub osc_port: u16,
+    pub projector_mode_enabled: bool,
+    pub projector_quality: ProjectorQuality,
     pub transition_time: f32,
     pub user_data_dir: String,
     pub videos_dir: String,
@@ -40,6 +43,8 @@ impl Default for GlobalSettings {
             midi_control_in_port: String::new(),
             midi_control_out_port: String::new(),
             osc_port: DEFAULT_OSC_PORT,
+            projector_mode_enabled: false,
+            projector_quality: ProjectorQuality::Balanced,
             transition_time: 4.0,
             user_data_dir: storage::default_user_data_dir(),
             videos_dir: storage::default_videos_dir(),

--- a/xtal/src/runtime/web_view.rs
+++ b/xtal/src/runtime/web_view.rs
@@ -6,6 +6,7 @@ use super::registry::RuntimeRegistry;
 use crate::control::{ControlHub, ControlValue, UiControlConfig};
 use crate::core::util::HashMap;
 use crate::motion::TimingSource;
+use crate::runtime::projector::ProjectorQuality;
 
 pub type Sender = ipc_channel::ipc::IpcSender<Event>;
 pub type Receiver = ipc_channel::ipc::IpcReceiver<Event>;
@@ -152,6 +153,8 @@ pub enum Event {
         midi_output_ports: Vec<(usize, String)>,
         monitor_preview_enabled: bool,
         osc_port: u16,
+        projector_mode_enabled: bool,
+        projector_quality: ProjectorQuality,
         sketches_by_category: SketchesByCategory,
         #[serde(default)]
         sketch_catalog: Option<Vec<SketchCatalogCategory>>,
@@ -187,6 +190,8 @@ pub enum Event {
     OpenOsDir(OsDir),
     Paused(bool),
     PerfMode(bool),
+    ProjectorMode(bool),
+    ProjectorQuality(ProjectorQuality),
     QueueRecord,
     Quit,
     Randomize(Exclusions),
@@ -273,6 +278,12 @@ pub fn map_event_to_runtime_event(event: &Event) -> Option<RuntimeEvent> {
         Event::OpenOsDir(kind) => Some(RuntimeEvent::OpenOsDir(kind.clone())),
         Event::Paused(paused) => Some(RuntimeEvent::Pause(*paused)),
         Event::PerfMode(enabled) => Some(RuntimeEvent::SetPerfMode(*enabled)),
+        Event::ProjectorMode(enabled) => {
+            Some(RuntimeEvent::SetProjectorMode(*enabled))
+        }
+        Event::ProjectorQuality(quality) => {
+            Some(RuntimeEvent::SetProjectorQuality(*quality))
+        }
         Event::QueueRecord => Some(RuntimeEvent::QueueRecord),
         Event::Randomize(exclusions) => {
             Some(RuntimeEvent::Randomize(exclusions.clone()))
@@ -408,6 +419,18 @@ mod tests {
         assert_eq!(
             monitor_preview,
             Some(RuntimeEvent::SetMonitorPreview(true))
+        );
+
+        let projector_mode =
+            map_event_to_runtime_event(&Event::ProjectorMode(true));
+        assert_eq!(projector_mode, Some(RuntimeEvent::SetProjectorMode(true)));
+
+        let projector_quality = map_event_to_runtime_event(
+            &Event::ProjectorQuality(ProjectorQuality::Fast),
+        );
+        assert_eq!(
+            projector_quality,
+            Some(RuntimeEvent::SetProjectorQuality(ProjectorQuality::Fast))
         );
     }
 
@@ -626,6 +649,8 @@ mod tests {
             Event::TransitionTime(2.5),
             Event::Paused(true),
             Event::PerfMode(true),
+            Event::ProjectorMode(true),
+            Event::ProjectorQuality(ProjectorQuality::Emergency),
             Event::MonitorPreview(true),
             Event::MappingsEnabled(false),
             Event::Exclusions(vec!["foo".into()]),

--- a/xtal/tests/control_hub_snapshot_transition.rs
+++ b/xtal/tests/control_hub_snapshot_transition.rs
@@ -6,61 +6,80 @@ use xtal::time::frame_clock;
 
 fn hub_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../sketches/src/sketches/main/grid_splash_bw.yaml")
+        .join("../sketches/src/drafts/grid_splash_bw.yaml")
 }
 
 #[test]
 fn debug_snapshot_grid_transition_progression() {
+    const FPS: f32 = 60.0;
+    const BPM: f32 = 134.0;
+    const TRANSITION_BEATS: f32 = 4.0;
+
     let path = hub_path();
     assert!(path.exists(), "missing test yaml at {}", path.display());
 
-    frame_clock::set_fps(60.0);
-    frame_clock::set_paused(false);
+    frame_clock::set_fps(FPS);
+    frame_clock::set_paused(true);
     frame_clock::set_frame_count(0);
+    frame_clock::set_elapsed_seconds(0.0);
 
-    let timing = Timing::frame(Bpm::new(134.0));
+    let timing = Timing::frame(Bpm::new(BPM));
     let mut hub = ControlHub::from_path(path, timing);
-    hub.set_transition_time(4.0);
+    hub.set_transition_time(TRANSITION_BEATS);
 
     // Snapshot A defaults.
     hub.take_snapshot("a");
 
     // Snapshot B with obvious deltas.
-    hub.ui_controls.set("ab_mix", ControlValue::Float(1.0));
-    hub.ui_controls.set("a_freq", ControlValue::Float(1.0));
+    hub.ui_controls.set("colorize", ControlValue::Float(1.0));
+    hub.ui_controls
+        .set("norm_color_disp", ControlValue::Float(1.0));
     hub.ui_controls.set("feedback", ControlValue::Float(1.0));
     hub.take_snapshot("b");
 
     // Back to A values, then recall B.
-    hub.ui_controls.set("ab_mix", ControlValue::Float(0.0));
-    hub.ui_controls.set("a_freq", ControlValue::Float(0.0));
+    hub.ui_controls.set("colorize", ControlValue::Float(0.0));
+    hub.ui_controls
+        .set("norm_color_disp", ControlValue::Float(0.0));
     hub.ui_controls.set("feedback", ControlValue::Float(0.0));
 
     hub.recall_snapshot("b").unwrap();
 
     let sample = |hub: &ControlHub<Timing>, frame: u32| -> (f32, f32, f32) {
         frame_clock::set_frame_count(frame);
-        (hub.get("ab_mix"), hub.get("a_freq"), hub.get("feedback"))
+        frame_clock::set_elapsed_seconds(frame as f32 / FPS);
+        (
+            hub.get("colorize"),
+            hub.get("norm_color_disp"),
+            hub.get("feedback"),
+        )
     };
 
+    let end_frame =
+        ((TRANSITION_BEATS * FPS * 60.0 / BPM).ceil() as u32).max(1);
     let f0 = sample(&hub, 0);
     let f10 = sample(&hub, 10);
     let f30 = sample(&hub, 30);
     let f60 = sample(&hub, 60);
-    let f119 = sample(&hub, 119);
+    let f_before_end = sample(&hub, end_frame - 1);
 
     // End transition and apply terminal values.
-    frame_clock::set_frame_count(120);
+    frame_clock::set_frame_count(end_frame);
+    frame_clock::set_elapsed_seconds(end_frame as f32 / FPS);
     hub.update();
-    let fend = sample(&hub, 120);
+    let fend = sample(&hub, end_frame);
 
     eprintln!(
-        "f0={:?} f10={:?} f30={:?} f60={:?} f119={:?} fend={:?}",
-        f0, f10, f30, f60, f119, fend
+        "f0={:?} f10={:?} f30={:?} f60={:?} f_before_end={:?} fend={:?}",
+        f0, f10, f30, f60, f_before_end, fend
     );
 
     // A few sanity checks: should move toward 1.0 and end at/near 1.0.
     assert!(f10.0 >= f0.0);
     assert!(f30.0 >= f10.0);
-    assert!(fend.0 > 0.9);
+    assert!(f60.0 >= f30.0);
+    assert!(f_before_end.0 >= f60.0);
+    assert!((fend.0 - 1.0).abs() < 0.001);
+    assert!((fend.1 - 1.0).abs() < 0.001);
+    assert!((fend.2 - 1.0).abs() < 0.001);
 }

--- a/xtal/tests/runtime_web_view_event_mapping.rs
+++ b/xtal/tests/runtime_web_view_event_mapping.rs
@@ -1,5 +1,6 @@
 use xtal::graph::GraphBuilder;
 use xtal::prelude::*;
+use xtal::runtime::projector::ProjectorQuality;
 
 struct TestSketch;
 
@@ -260,6 +261,8 @@ fn web_view_init_serializes_optional_sketch_catalog_in_camel_case() {
         midi_output_ports: vec![],
         monitor_preview_enabled: false,
         osc_port: 0,
+        projector_mode_enabled: false,
+        projector_quality: ProjectorQuality::Balanced,
         sketches_by_category,
         sketch_catalog: Some(vec![web_view::SketchCatalogCategory {
             title: "Main".to_string(),


### PR DESCRIPTION
Add a persisted Projector Mode setting that limits internal shader
resolution while preserving the actual window and projector dimensions.

Render patches to a framework-owned internal texture when scaling is
needed, then upscale the final output to the surface. Apply the internal
resolution consistently to graph textures, compute dispatches, shader
resolution uniforms, captures, recordings, and monitor previews.

Add named quality presets based on pixel-work budgets:
- Crisp: 2560x1440 equivalent
- Balanced: 1920x1080 equivalent
- Fast: 1280x720 equivalent
- Faster: 1120x630 equivalent
- Emergency: 960x540 equivalent

Preserve the output aspect ratio for arbitrary projector dimensions and
render natively whenever the surface is already below the selected
budget.

Add Projector Mode controls as the first Settings section, with an
Enable toggle and Quality dropdown. Persist both values globally across
launches and sketches.

Add an animated projector stress patch with fine moving contours and an
adjustable workload so render scaling performance and visual quality can
be evaluated locally by resizing the window.

Stabilize timing-sensitive animation and snapshot-transition tests, and
add coverage for:
- projector size calculations across common and unusual aspect ratios
- persisted settings and UI event mapping
- direct-to-surface and graph presentation paths
- stress shader WGSL validation